### PR TITLE
feat: add kms for gluejob

### DIFF
--- a/cloudformation/glueJob.yml
+++ b/cloudformation/glueJob.yml
@@ -3,8 +3,41 @@ Parameters:
   scriptsBucket:
     Type: String
     Description: S3 bucket name where scripts will be uploaded
+  kmsKeyArnForCsv2Parquet:
+    Type: String
+    Description: KMS Key ARN for encrypting data in GlueJobCsv2Parquet
+  kmsKeyArnForETL:
+    Type: String
+    Description: KMS Key ARN for encrypting data in GlueJobETL
 
 Resources:
+  GlueJobRoleForDataEngineering:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: GlueJobRoleForDataEngineering
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: glue.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+      Policies:
+        - PolicyName: GlueJobEncryptDecrypt-KmsKey
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: "VisualEditor0"
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:Encrypt
+                  - kms:GenerateDataKey
+                Resource: !Ref kmsKeyArnForCsv2Parquet
+
   GlueJobRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -19,21 +52,58 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
         - arn:aws:iam::aws:policy/AmazonS3FullAccess
+      Policies:
+        - PolicyName: GlueJobEncryptDecrypt-KmsKey
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: "AllowDecrypt"
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                Resource: !Ref kmsKeyArnForETL
+              - Sid: "AllowEncryptAndGenerateDataKey"
+                Effect: Allow
+                Action:
+                  - kms:Encrypt
+                  - kms:GenerateDataKey
+                Resource: "arn:aws:kms:ap-southeast-2:339713004220:key/a922aa60-b15b-44eb-bd2a-a47b47f11293"
+
+  GlueSecurityConfigurationForCsv2Parquet:
+    Type: 'AWS::Glue::SecurityConfiguration'
+    Properties:
+      Name: GlueSecurityConfigurationForCsv2Parquet
+      EncryptionConfiguration:
+        S3Encryptions:
+          - S3EncryptionMode: SSE-KMS
+            KmsKeyArn: !Ref kmsKeyArnForCsv2Parquet
+
+  GlueSecurityConfigurationForETL:
+    Type: 'AWS::Glue::SecurityConfiguration'
+    Properties:
+      Name: GlueSecurityConfigurationForETL
+      EncryptionConfiguration:
+        S3Encryptions:
+          - S3EncryptionMode: SSE-KMS
+            KmsKeyArn: !Ref kmsKeyArnForETL
 
   GlueJobCsv2Parquet:
     Type: 'AWS::Glue::Job'
     Properties:
       Name: GlueJobCsv2Parquet
-      Role: !GetAtt GlueJobRole.Arn
+      Role: !GetAtt GlueJobRoleForDataEngineering.Arn
       Command:
         Name: glueetl
         ScriptLocation: !Sub s3://${scriptsBucket}/gluejob/csv2parquet.py
         PythonVersion: '3'
       DefaultArguments:
         '--job-bookmark-option': 'job-bookmark-enable'
+        '--encryption-type': 'SSE-KMS'
+        '--kms-key-arn': !Ref kmsKeyArnForCsv2Parquet
       GlueVersion: '4.0'
       MaxCapacity: 2.0
       Timeout: 5
+      SecurityConfiguration: !Ref GlueSecurityConfigurationForCsv2Parquet
 
   GlueJobETL:
     Type: 'AWS::Glue::Job'
@@ -46,6 +116,9 @@ Resources:
         PythonVersion: '3'
       DefaultArguments:
         '--job-bookmark-option': 'job-bookmark-enable'
+        '--encryption-type': 'SSE-KMS'
+        '--kms-key-arn': !Ref kmsKeyArnForETL
       GlueVersion: '4.0'
       MaxCapacity: 2.0
       Timeout: 10
+      SecurityConfiguration: !Ref GlueSecurityConfigurationForETL


### PR DESCRIPTION
Added KSM for gluejob:
- add saftey configuration;
- kmsKeyArnForCsv2Parquet: The KMS key ARN for GlueJobCsv2Parquet.
- kmsKeyArnForETL: The KMS key ARN for GlueJobETL
- GlueJobCsv2Parquet: use GlueJobRoleForDataEngineering role, and configure the safety use of KMS key encryption type and configuration.
- GlueJobETL: Uses the GlueJobRole role and configures the encryption type and security configuration using the KMS key.

Resolve DE-50